### PR TITLE
Add stub support for variable font tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 font
 ====
 
+[![Build Status](https://travis-ci.org/ConradIrwin/font.svg?branch=master)](https://travis-ci.org/ConradIrwin/font) [![GoDoc](https://godoc.org/github.com/ConradIrwin/font?status.svg)](https://godoc.org/github.com/ConradIrwin/font)
 
 A collection of Go packages for parsing and encoding OpenType fonts.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 font
 ====
 
-[![Build Status](https://travis-ci.org/ConradIrwin/font.svg?branch=master)](https://travis-ci.org/ConradIrwin/font) [![GoDoc](https://godoc.org/github.com/ConradIrwin/font?status.svg)](https://godoc.org/github.com/ConradIrwin/font)
 
 A collection of Go packages for parsing and encoding OpenType fonts.
 

--- a/sfnt/font.go
+++ b/sfnt/font.go
@@ -167,6 +167,66 @@ func (font *Font) GsubTable() (*TableLayout, error) {
 	return font.TableLayout(TagGsub)
 }
 
+// FvarTable returns the font variations table identified with the 'fvar' tag.
+func (font *Font) FvarTable() (*TableFvar, error) {
+	t, err := font.Table(TagFvar)
+	if err != nil {
+		return nil, err
+	}
+	return t.(*TableFvar), nil
+}
+
+// AvarTable returns the axis variations table identified with the 'avar' tag.
+func (font *Font) AvarTable() (*TableAvar, error) {
+	t, err := font.Table(TagAvar)
+	if err != nil {
+		return nil, err
+	}
+	return t.(*TableAvar), nil
+}
+
+// GvarTable returns the glyph variations table identified with the 'gvar' tag.
+func (font *Font) GvarTable() (*TableGvar, error) {
+	t, err := font.Table(TagGvar)
+	if err != nil {
+		return nil, err
+	}
+	return t.(*TableGvar), nil
+}
+
+// StatTable returns the style attributes table identified with the 'STAT' tag.
+func (font *Font) StatTable() (*TableStat, error) {
+	t, err := font.Table(TagStat)
+	if err != nil {
+		return nil, err
+	}
+	return t.(*TableStat), nil
+}
+
+// HvarTable returns the horizontal metrics variations table identified with the 'HVAR' tag.
+func (font *Font) HvarTable() (*TableHvar, error) {
+	t, err := font.Table(TagHvar)
+	if err != nil {
+		return nil, err
+	}
+	return t.(*TableHvar), nil
+}
+
+// MvarTable returns the metrics variations table identified with the 'MVAR' tag.
+func (font *Font) MvarTable() (*TableMvar, error) {
+	t, err := font.Table(TagMvar)
+	if err != nil {
+		return nil, err
+	}
+	return t.(*TableMvar), nil
+}
+
+// IsVariable returns true if this font contains an 'fvar' table,
+// indicating it is a variable font.
+func (font *Font) IsVariable() bool {
+	return font.HasTable(TagFvar)
+}
+
 func (font *Font) Table(tag Tag) (Table, error) {
 	s, found := font.tables[tag]
 	if !found {

--- a/sfnt/table.go
+++ b/sfnt/table.go
@@ -12,6 +12,12 @@ var parsers = map[Tag]tableParser{
 	TagOS2:  parseTableOS2,
 	TagGpos: parseTableLayout,
 	TagGsub: parseTableLayout,
+	TagFvar: parseTableFvar,
+	TagAvar: parseTableAvar,
+	TagGvar: parseTableGvar,
+	TagStat: parseTableStat,
+	TagHvar: parseTableHvar,
+	TagMvar: parseTableMvar,
 }
 
 // Table is an interface for each section of the font file.

--- a/sfnt/table_avar.go
+++ b/sfnt/table_avar.go
@@ -1,0 +1,20 @@
+package sfnt
+
+// TableAvar contains the axis variations table, which provides
+// optional fine-tuning of the variation space by remapping axis values.
+// See https://learn.microsoft.com/en-us/typography/opentype/spec/avar
+type TableAvar struct {
+	baseTable
+	bytes []byte
+}
+
+func parseTableAvar(tag Tag, buf []byte) (Table, error) {
+	return &TableAvar{
+		baseTable: baseTable(tag),
+		bytes:     buf,
+	}, nil
+}
+
+func (t *TableAvar) Bytes() []byte {
+	return t.bytes
+}

--- a/sfnt/table_fvar.go
+++ b/sfnt/table_fvar.go
@@ -1,0 +1,20 @@
+package sfnt
+
+// TableFvar contains the font variations table, which defines the
+// variation axes and named instances for a variable font.
+// See https://learn.microsoft.com/en-us/typography/opentype/spec/fvar
+type TableFvar struct {
+	baseTable
+	bytes []byte
+}
+
+func parseTableFvar(tag Tag, buf []byte) (Table, error) {
+	return &TableFvar{
+		baseTable: baseTable(tag),
+		bytes:     buf,
+	}, nil
+}
+
+func (t *TableFvar) Bytes() []byte {
+	return t.bytes
+}

--- a/sfnt/table_gvar.go
+++ b/sfnt/table_gvar.go
@@ -1,0 +1,20 @@
+package sfnt
+
+// TableGvar contains the glyph variations table, which defines
+// how TrueType glyph outlines vary across the font's variation axes.
+// See https://learn.microsoft.com/en-us/typography/opentype/spec/gvar
+type TableGvar struct {
+	baseTable
+	bytes []byte
+}
+
+func parseTableGvar(tag Tag, buf []byte) (Table, error) {
+	return &TableGvar{
+		baseTable: baseTable(tag),
+		bytes:     buf,
+	}, nil
+}
+
+func (t *TableGvar) Bytes() []byte {
+	return t.bytes
+}

--- a/sfnt/table_hvar.go
+++ b/sfnt/table_hvar.go
@@ -1,0 +1,20 @@
+package sfnt
+
+// TableHvar contains the horizontal metrics variations table, which
+// describes how horizontal glyph metrics vary across variation axes.
+// See https://learn.microsoft.com/en-us/typography/opentype/spec/hvar
+type TableHvar struct {
+	baseTable
+	bytes []byte
+}
+
+func parseTableHvar(tag Tag, buf []byte) (Table, error) {
+	return &TableHvar{
+		baseTable: baseTable(tag),
+		bytes:     buf,
+	}, nil
+}
+
+func (t *TableHvar) Bytes() []byte {
+	return t.bytes
+}

--- a/sfnt/table_mvar.go
+++ b/sfnt/table_mvar.go
@@ -1,0 +1,20 @@
+package sfnt
+
+// TableMvar contains the metrics variations table, which describes
+// how font-wide metrics vary across the font's variation axes.
+// See https://learn.microsoft.com/en-us/typography/opentype/spec/mvar
+type TableMvar struct {
+	baseTable
+	bytes []byte
+}
+
+func parseTableMvar(tag Tag, buf []byte) (Table, error) {
+	return &TableMvar{
+		baseTable: baseTable(tag),
+		bytes:     buf,
+	}, nil
+}
+
+func (t *TableMvar) Bytes() []byte {
+	return t.bytes
+}

--- a/sfnt/table_stat.go
+++ b/sfnt/table_stat.go
@@ -1,0 +1,21 @@
+package sfnt
+
+// TableStat contains the style attributes table, which describes
+// design axes and their values for variable and non-variable fonts.
+// Required for variable fonts.
+// See https://learn.microsoft.com/en-us/typography/opentype/spec/stat
+type TableStat struct {
+	baseTable
+	bytes []byte
+}
+
+func parseTableStat(tag Tag, buf []byte) (Table, error) {
+	return &TableStat{
+		baseTable: baseTable(tag),
+		bytes:     buf,
+	}, nil
+}
+
+func (t *TableStat) Bytes() []byte {
+	return t.bytes
+}

--- a/sfnt/tag.go
+++ b/sfnt/tag.go
@@ -25,6 +25,19 @@ var (
 	// TagGsub represents the 'GSUB' table, which contains Glyph Substitution features
 	TagGsub = MustNamedTag("GSUB")
 
+	// TagFvar represents the 'fvar' table, which contains font variation axis definitions
+	TagFvar = MustNamedTag("fvar")
+	// TagAvar represents the 'avar' table, which contains axis variation remapping
+	TagAvar = MustNamedTag("avar")
+	// TagGvar represents the 'gvar' table, which contains glyph variation data
+	TagGvar = MustNamedTag("gvar")
+	// TagStat represents the 'STAT' table, which contains style attributes
+	TagStat = MustNamedTag("STAT")
+	// TagHvar represents the 'HVAR' table, which contains horizontal metrics variations
+	TagHvar = MustNamedTag("HVAR")
+	// TagMvar represents the 'MVAR' table, which contains metrics variations
+	TagMvar = MustNamedTag("MVAR")
+
 	// TypeTrueType is the first four bytes of an OpenType file containing a TrueType font
 	TypeTrueType = Tag{0x00010000}
 	// TypeAppleTrueType is the first four bytes of an OpenType file containing a TrueType font


### PR DESCRIPTION
## Summary
- Adds stub table types and parsers for the six OpenType font variations tables: `fvar`, `avar`, `gvar`, `STAT`, `HVAR`, `MVAR`
- Registers corresponding `Tag` constants and wires up parsers in the parser map
- Adds typed accessor methods on `Font` (`FvarTable()`, `AvarTable()`, etc.) and an `IsVariable()` convenience method

## Test plan
- [x] Project compiles cleanly with `go build ./...`
- [ ] Existing tests continue to pass
- [ ] Load a variable font (e.g. a `.ttf` with `fvar`) and confirm `IsVariable()` returns true and table accessors return non-nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)